### PR TITLE
Allow collection as entity in browse_releases_by

### DIFF
--- a/R/browse.R
+++ b/R/browse.R
@@ -142,7 +142,7 @@ browse_recordings_by <- function(entity, mbid, includes=NULL, limit=NULL, offset
 
 #' Browse releases by related id
 #'
-#' @param entity area, artist, label, recording, release-group
+#' @param entity area, artist, collection, label, recording, release-group
 #'
 #' @param mbid id of an object, specified by entity
 #' @param includes artists, labels, recordings, release-groups,  media, recordings
@@ -156,8 +156,8 @@ browse_recordings_by <- function(entity, mbid, includes=NULL, limit=NULL, offset
 #' browse_releases_by("artist", "0103c1cc-4a09-4a5d-a344-56ad99a77193")
 #' @export
 browse_releases_by <- function(entity, mbid, includes=NULL, limit=NULL, offset=NULL) {
-  allowed_entities <- c("area", "artist", "label", "recording", "release-group") #"track", "track_artist"
   available_includes <- c("artists", "labels", "recordings", "release-groups", "media", "recordings") #"discids", "isrcs",
+  allowed_entities <- c("area", "artist", "collection", "label", "recording", "release-group") #"track", "track_artist"
   mb_browse(context="release", entity, mbid, includes, limit, offset,
             allowed_entities, available_includes)
 }

--- a/R/browse.R
+++ b/R/browse.R
@@ -145,7 +145,7 @@ browse_recordings_by <- function(entity, mbid, includes=NULL, limit=NULL, offset
 #' @param entity area, artist, collection, label, recording, release-group
 #'
 #' @param mbid id of an object, specified by entity
-#' @param includes artists, labels, recordings, release-groups,  media, recordings
+#' @param includes artists, labels, media, recordings, release-groups
 #' @param limit restrict number of records retrieved from musicbrainz database
 #' @param offset number of records to skip
 #'
@@ -156,8 +156,8 @@ browse_recordings_by <- function(entity, mbid, includes=NULL, limit=NULL, offset
 #' browse_releases_by("artist", "0103c1cc-4a09-4a5d-a344-56ad99a77193")
 #' @export
 browse_releases_by <- function(entity, mbid, includes=NULL, limit=NULL, offset=NULL) {
-  available_includes <- c("artists", "labels", "recordings", "release-groups", "media", "recordings") #"discids", "isrcs",
   allowed_entities <- c("area", "artist", "collection", "label", "recording", "release-group") #"track", "track_artist"
+  available_includes <- c("artists", "labels", "media", "recordings", "release-groups") #"discids", "isrcs",
   mb_browse(context="release", entity, mbid, includes, limit, offset,
             allowed_entities, available_includes)
 }

--- a/man/browse_releases_by.Rd
+++ b/man/browse_releases_by.Rd
@@ -12,7 +12,7 @@ browse_releases_by(entity, mbid, includes = NULL, limit = NULL,
 
 \item{mbid}{id of an object, specified by entity}
 
-\item{includes}{artists, labels, recordings, release-groups,  media, recordings}
+\item{includes}{artists, labels, media, recordings, release-groups}
 
 \item{limit}{restrict number of records retrieved from musicbrainz database}
 

--- a/man/browse_releases_by.Rd
+++ b/man/browse_releases_by.Rd
@@ -8,7 +8,7 @@ browse_releases_by(entity, mbid, includes = NULL, limit = NULL,
   offset = NULL)
 }
 \arguments{
-\item{entity}{area, artist, label, recording, release-group}
+\item{entity}{area, artist, collection, label, recording, release-group}
 
 \item{mbid}{id of an object, specified by entity}
 


### PR DESCRIPTION
This is useful for downloading all the releases in a collection.

I've also tidied up available_includes (with no difference in functionality).